### PR TITLE
Various upgrades, bumping to version 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["accessibility", "a11y"]
 categories = ["api-bindings"]
 license = "MIT"
 version = "0.1.1"
+edition = "2018"
 
 [dependencies]
 tolk-sys = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ readme = "README.md"
 keywords = ["accessibility", "a11y"]
 categories = ["api-bindings"]
 license = "MIT"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2018"
 
 [dependencies]
-tolk-sys = { path = "../tolk-sys" }
+tolk-sys = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ version = "0.1.1"
 edition = "2018"
 
 [dependencies]
-tolk-sys = "0.1.0"
+tolk-sys = { path = "../tolk-sys" }

--- a/README.md
+++ b/README.md
@@ -1,26 +1,19 @@
 # Tolk-rs
+
 Rust bindings to [Tolk](https://github.com/dkager/tolk), a screen reader abstraction library
 
 ## Note
+
 This library is meant to be used in the context of providing a screen reader some text to speak. If you're a sighted developer and want general UI accessibility, this library isn't for you. Please use the more powerful native accessibility APIs provided by the OS. Using this library also means that tools for other disabilities (such as magnifiers, voice dictation, etc.) will not be able to understand your UI.
 
 ## Installation
-Download tolk.zip from [here](https://ci.appveyor.com/api/projects/dkager/tolk/artifacts/tolk.zip?branch=master) and:
-* Unzip it to wherever you want
-* Copy bin\\{x86, x64}\tolk.lib to:
-  * C:\Users\\{Your Username}\\.multirust\toolchains\\{current toolchain}\lib\rustlib\\{current toolchain}\lib if you're using rustup
-  * C:\Program Files\Rust\lib\rustlib\x86_64-pc-windows-msvc\lib if you're using a default rust installation
-  * LIB if you have the LIB environment variable defined
-* Copy bin\\{x86, x64}\tolk.dll to the directory with your project's Cargo.toml
-* Copy everything from the lib directory to the directory with your project's Cargo.toml
 
-(x86 and x64 is the kind of rust binaries you have)
-And add this to your Cargo.toml (or use cargo add if you have that):
-> tolk = "0.1"
+Add this to your Cargo.toml (or use cargo add if you have that):
+
+```toml
+tolk = "0.2"
+```
 
 ## Documentation
-Documentation is auto-generated [here](https://docs.rs/tolk/*/x86_64-pc-windows-msvc/tolk/). You don't really need anything else.
 
-## Todo
-* Error handling
-* Make speak, output, and braille only work if DetectScreenReader returns a string
+Documentation is auto-generated [here](https://docs.rs/tolk/*/x86_64-pc-windows-msvc/tolk/). You don't really need anything else.

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -10,7 +10,11 @@ fn main() -> io::Result<()> {
         println!("No screen reader detected");
     }
     tolk.try_sapi(true);
-    println!("Has speech: {}, has Braille: {}", tolk.has_speech(), tolk.has_braille());
+    println!(
+        "Has speech: {}, has Braille: {}",
+        tolk.has_speech(),
+        tolk.has_braille()
+    );
     tolk.output("Hello, world.", true);
     tolk.speak("This wil only speak.", false);
     tolk.braille("This will only be brailled.");

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,0 +1,20 @@
+use std::io;
+
+use tolk::Tolk;
+
+fn main() -> io::Result<()> {
+    let tolk = Tolk::new();
+    if let Some(screen_reader) = tolk.detect_screen_reader() {
+        println!("Detected screen reader: {}", screen_reader);
+    } else {
+        println!("No screen reader detected");
+    }
+    tolk.try_sapi(true);
+    println!("Has speech: {}, has Braille: {}", tolk.has_speech(), tolk.has_braille());
+    tolk.output("Hello, world.", true);
+    tolk.speak("This wil only speak.", false);
+    tolk.braille("This will only be brailled.");
+    let mut _input = String::new();
+    io::stdin().read_line(&mut _input)?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
-#![cfg(windows)]
-extern crate tolk_sys;
-
+#[cfg(target_os = "windows")]
 use std::ffi::OsStr;
 use std::os::windows::ffi::OsStrExt;
 use std::slice::from_raw_parts;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,18 @@ impl Tolk {
         Tolk
     }
 
+    pub fn try_sapi(&self, v: bool) {
+        unsafe {
+            Tolk_TrySAPI(v);
+        }
+    }
+
+    pub fn prefer_sapi(&self, v: bool) {
+        unsafe {
+            Tolk_PreferSAPI(v);
+        }
+    }
+
     pub fn detect_screen_reader(&self) -> Option<String> {
         let screen_reader = unsafe {
             Tolk_DetectScreenReader()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,18 @@ impl Tolk {
         }
     }
 
+    pub fn has_speech(&self) -> bool {
+        unsafe {
+            Tolk_HasSpeech()
+        }
+    }
+
+    pub fn has_braille(&self) -> bool {
+        unsafe {
+            Tolk_HasBraille()
+        }
+    }
+
     pub fn detect_screen_reader(&self) -> Option<String> {
         let screen_reader = unsafe {
             Tolk_DetectScreenReader()
@@ -53,6 +65,18 @@ impl Tolk {
     pub fn braille<S: Into<String>>(&self, s: S) -> bool {
         unsafe {
             Tolk_Braille(str_to_wchar_t(&s.into()))
+        }
+    }
+
+    pub fn is_speaking(&self) -> bool {
+        unsafe {
+            Tolk_IsSpeaking()
+        }
+    }
+
+    pub fn silence(&self) -> bool {
+        unsafe {
+            Tolk_Silence()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,25 +27,15 @@ impl Tolk {
         }
     }
 
-    pub fn speak (&self, s: &str, interrupt: bool) {
-        if unsafe { Tolk_HasSpeech() } {
-            unsafe {
-                Tolk_Speak(str_to_wchar_t(s), interrupt);
-            }
-        } else {
-            // Fallback on self.output
-            self.output(s, interrupt)
+    pub fn speak (&self, s: &str, interrupt: bool) -> bool {
+        unsafe {
+            Tolk_Speak(str_to_wchar_t(s), interrupt)
         }
     }
 
-    pub fn braille (&self, s: &str) {
-        if unsafe { Tolk_HasBraille() } {
-            unsafe {
-                Tolk_Braille(str_to_wchar_t(s));
-            }
-        } else {
-            // Fallback on self.output
-            self.output(s, false);
+    pub fn braille (&self, s: &str) -> bool {
+        unsafe {
+            Tolk_Braille(str_to_wchar_t(s))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,21 +28,15 @@ impl Tolk {
     }
 
     pub fn has_speech(&self) -> bool {
-        unsafe {
-            Tolk_HasSpeech()
-        }
+        unsafe { Tolk_HasSpeech() }
     }
 
     pub fn has_braille(&self) -> bool {
-        unsafe {
-            Tolk_HasBraille()
-        }
+        unsafe { Tolk_HasBraille() }
     }
 
     pub fn detect_screen_reader(&self) -> Option<String> {
-        let screen_reader = unsafe {
-            Tolk_DetectScreenReader()
-        };
+        let screen_reader = unsafe { Tolk_DetectScreenReader() };
         if screen_reader.is_null() {
             None
         } else {
@@ -57,38 +51,36 @@ impl Tolk {
     }
 
     pub fn speak<S: Into<String>>(&self, s: S, interrupt: bool) -> bool {
-        unsafe {
-            Tolk_Speak(str_to_wchar_t(&s.into()), interrupt)
-        }
+        unsafe { Tolk_Speak(str_to_wchar_t(&s.into()), interrupt) }
     }
 
     pub fn braille<S: Into<String>>(&self, s: S) -> bool {
-        unsafe {
-            Tolk_Braille(str_to_wchar_t(&s.into()))
-        }
+        unsafe { Tolk_Braille(str_to_wchar_t(&s.into())) }
     }
 
     pub fn is_speaking(&self) -> bool {
-        unsafe {
-            Tolk_IsSpeaking()
-        }
+        unsafe { Tolk_IsSpeaking() }
     }
 
     pub fn silence(&self) -> bool {
-        unsafe {
-            Tolk_Silence()
-        }
+        unsafe { Tolk_Silence() }
     }
 }
 
 impl Drop for Tolk {
     fn drop(&mut self) {
-        unsafe { Tolk_Unload(); }
+        unsafe {
+            Tolk_Unload();
+        }
     }
 }
 
 fn str_to_wchar_t(s: &str) -> *const u16 {
-    OsStr::new(s).encode_wide().chain(Some(0).into_iter()).collect::<Vec<_>>().as_ptr()
+    OsStr::new(s)
+        .encode_wide()
+        .chain(Some(0).into_iter())
+        .collect::<Vec<_>>()
+        .as_ptr()
 }
 
 unsafe fn string_from_wchar_t(orig: *const u16) -> String {
@@ -109,5 +101,7 @@ fn test_drop_behavior() {
         assert_eq!(Tolk_IsLoaded(), true);
     }
 
-    unsafe { assert_eq!(Tolk_IsLoaded(), false); }
+    unsafe {
+        assert_eq!(Tolk_IsLoaded(), false);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,14 @@ impl Tolk {
         Tolk
     }
 
-    pub fn detect_screen_reader(&self) -> String {
-        unsafe {
-            return string_from_wchar_t(Tolk_DetectScreenReader());
+    pub fn detect_screen_reader(&self) -> Option<String> {
+        let screen_reader = unsafe {
+            Tolk_DetectScreenReader()
+        };
+        if screen_reader.is_null() {
+            None
+        } else {
+            Some(unsafe { string_from_wchar_t(screen_reader) })
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,21 +21,21 @@ impl Tolk {
         }
     }
 
-    pub fn output(&self, s: &str, interrupt: bool) {
+    pub fn output<S: Into<String>>(&self, s: S, interrupt: bool) {
         unsafe {
-            Tolk_Output(str_to_wchar_t(s), interrupt);
+            Tolk_Output(str_to_wchar_t(&s.into()), interrupt);
         }
     }
 
-    pub fn speak (&self, s: &str, interrupt: bool) -> bool {
+    pub fn speak<S: Into<String>>(&self, s: S, interrupt: bool) -> bool {
         unsafe {
-            Tolk_Speak(str_to_wchar_t(s), interrupt)
+            Tolk_Speak(str_to_wchar_t(&s.into()), interrupt)
         }
     }
 
-    pub fn braille (&self, s: &str) -> bool {
+    pub fn braille<S: Into<String>>(&self, s: S) -> bool {
         unsafe {
-            Tolk_Braille(str_to_wchar_t(s))
+            Tolk_Braille(str_to_wchar_t(&s.into()))
         }
     }
 }


### PR DESCRIPTION
These commits do a number of things:

 * Expose all remaining Tolk functions.
 * Make screen reader detection return an `Option<String>` to handle the null case, which currently crashes consumers.
 * If someone explicitly requests to speak or Braille text, don't fall back on `output`. Let's stick with the library's behavior on this one.
 * Use `Into<String>` everywhere `&str` was expected before, thus allowing any string-like value.
 * Add an example.
 * Update README.md and bump version.

I probably missed a few things, but the example works on my system, and I'll be actively using this crate for the time being. So if anything was missed, I'll attempt a fix and push out a change.

Thanks!